### PR TITLE
銀座Rails#41 点字メーカー bitwise版

### DIFF
--- a/lib/tenji_maker.rb
+++ b/lib/tenji_maker.rb
@@ -1,43 +1,80 @@
+# frozen_string_literal: true
+
+# nodoc:
 class TenjiMaker
   def to_tenji(text)
-    # 以下はサンプルの仮実装なので、このcase文は全部消して自作ロジックに書き直すこと
-    case text
-    when 'A HI RU'
-      <<~TENJI.chomp
-        o- o- oo
-        -- o- -o
-        -- oo --
-      TENJI
-    when 'KI RI N'
-      <<~TENJI.chomp
-        o- o- --
-        o- oo -o
-        -o -- oo
-      TENJI
-    when 'SI MA U MA'
-      <<~TENJI.chomp
-        o- o- oo o-
-        oo -o -- -o
-        -o oo -- oo
-      TENJI
-    when 'NI WA TO RI'
-      <<~TENJI.chomp
-        o- -- -o o-
-        o- -- oo oo
-        o- o- o- --
-      TENJI
-    when 'HI YO KO'
-      <<~TENJI.chomp
-        o- -o -o
-        o- -o o-
-        oo o- -o
-      TENJI
-    when 'KI TU NE'
-      <<~TENJI.chomp
-        o- oo oo
-        o- -o o-
-        -o o- o-
-      TENJI
-    end
+    text.split(' ')
+        .map { |char| to_bits(char) }
+        .map { |bits| to_tenji_array(bits) }
+        .transpose
+        .map { |line| line.join(' ') }
+        .join("\n")
+    # to_bits:
+    #   ローマ文を点字ビットパターンへ変換
+    #     [
+    #       1文字目のビットパターン,
+    #       2文字目のビットパターン,
+    #       ...
+    #     ]
+    # to_tenji_array:
+    #   点字ビットパターンを行毎に分割した点字文字列へ変換
+    #     [
+    #       [ 1文字目1行目, 1文字目2行目, 1文字目3行目 ],
+    #       [ 2文字目1行目, 2文字目2行目, 2文字目3行目 ],
+    #       ...
+    #     ]
+    # transpose:
+    #   配列を文字毎から行毎へ変換
+    #     [
+    #       [ 1文字目1行目, 2文字目1行目, ...],
+    #       [ 1文字目2行目, 2文字目2行目, ...],
+    #       [ 1文字目3行目, 2文字目3行目, ...]
+    #     ]
   end
+
+  private
+
+  def to_bits(char)
+    # char を(子)(母)に分割
+    # (子)(母)の組み合わせからビットパターンを生成
+    /^(.)?(.)$/.match(char)
+               .captures
+               .then { |c1, c2| SIIN[c1][BOIN[c2]] }
+  end
+
+  def to_tenji_array(bits)
+    format('%06b', bits).tr('01', '-o').scan(/../)
+  end
+
+  # http://www.naiiv.net/braille/?tenji-sikumi
+  # ビット列は文字の出力順に合わせており、
+  # 上記サイトの (1)(4)_(2)(5)_(3)(6) の並びに相当する。
+  BOIN = {
+    'A' => 0b10_00_00,
+    'I' => 0b10_10_00,
+    'U' => 0b11_00_00,
+    'E' => 0b11_10_00,
+    'O' => 0b01_10_00,
+    'N' => 0b00_01_11
+  }.freeze
+  SIIN = {
+    nil => ->(b) { b },
+    'K' => ->(b) { b | 0b00_00_01 },
+    'S' => ->(b) { b | 0b00_01_01 },
+    'T' => ->(b) { b | 0b00_01_10 },
+    'N' => ->(b) { b | 0b00_00_10 },
+    'H' => ->(b) { b | 0b00_00_11 },
+    'M' => ->(b) { b | 0b00_01_11 },
+    'R' => ->(b) { b | 0b00_01_00 },
+    'Y' => ->(b) { shift(b) | 0b01_00_00 },
+    'W' => ->(b) { shift(b) | 0b00_00_00 }
+  }.freeze
+
+  def self.shift(bits)
+    # 0b00_11_00 との & で 2段目のデータ有無を判定し、
+    # 2段目があれば 1行(2ビット)だけシフト、
+    # 2段目がなければ 2行(4ビット)だけシフトする
+    bits >> ((bits & 0b00_11_00).positive? ? 2 : 4)
+  end
+  private_class_method :shift
 end

--- a/test/tenji_maker_test.rb
+++ b/test/tenji_maker_test.rb
@@ -63,4 +63,12 @@ class TenjiMakerTest < Minitest::Test
   # ここから上のテストは変更不可 =====================
 
   # 独自のテストパターンを追加するのは自由です
+  def test_re_n_ko_n
+    tenji = @tenji_maker.to_tenji('RE N KO N')
+    assert_equal <<~TENJI.chomp, tenji
+      oo -- -o --
+      oo -o o- -o
+      -- oo -o oo
+    TENJI
+  end
 end


### PR DESCRIPTION
コードのアピールポイント
===============

「点字の仕組み」に目を通して感じた「ああ、これ、ビット演算だな」をわりと素直に実装したコードです。

濁音、長音などを扱うのは面倒そうだと思いましたが、今回の仕様からは除外されていたので楽できました。

一文字分の6ドット文字列 `"o-o-o-"` を2ドット毎の配列 `[ "o-'", "o-", "o-" ]` に分離する処理が `scan` で素直に実装できて良かったです。
`scan` は何度か世話になっているのですが何故か存在を忘れがちです。
当初 `each_char.each_slice(2).map(&:join)` の様なロジックが必要になるかと考えてました。

配列を文字毎から行毎へ  `transpose` 一発で変換できたのは上手かったです。
ロジックを自作する前に見付けられて良かったです。

### 苦労した点

や行や「わ」の取り扱いが厄介でしたが、手続きオブジェクトを挟むことで綺麗に収まりました。
`p.call(x)` の代わりに `p[x]` と書けるので よりスッキリしました。
ア行の子音なしを `nil ` で表現できたので、これまたスッキリしました。

当初 `to_bits` および `to_tenji_array` のロジックは全て `to_tenji` に組み込んでいましたが、RuboCop の警告を消すため分離しました。
分離したことでロジックはすっきりしたと思いますが、メソッド名をどうするかやたら悩みました。
今のものもそれほど良いものとは思っていません。

`{ |char| to_bits(char) }` で `char` が二回表われるのを嫌がって`&method(:to_bits)` とやってみましたが、むしろ分かりにくくなっただけに感じたので戻しています。
`&:to_bits` と同程度にすっきり表現できれば良いと思いましたが、`method`  が冗長に感じました。
...
ふと「refine はこういう場合に使えるものでは」と思い付き、 [hotfix/callbacks-by-refinement](https://github.com/JunichiIto/tenji-maker-challenge-for-ginza-rails/compare/main...ysjj:hotfix/callbacks-by-refinement?expand=1)で実装してみました。
`to_tenji` は狙い通りスッキリしましたが、このコード量では「refinement 実装は `using` に先立つ必要がある」が嬉しさを減じますね。

### etc

業務で書くなら、全ての点字ドットパターンの文字列 / 配列をハッシュで持ちますかね。
50 ~ 100文字 / ドットパターン程度なら変にロジックを組むよりメンテしやすい気もします。
これのデメリットは1文字だけ誤パターンが紛れ込んでも気付きにくいことでしょうか。

テストケースを1つ追加しています。
このケースの意図は「 `n` が途中に含まれる場合の確認」です。

### 辛口バージョン
[feature/hot-version](https://github.com/JunichiIto/tenji-maker-challenge-for-ginza-rails/compare/main...ysjj:feature/hot-version?expand=1)で実装してみました。

基本的なロジックは変えずに済んでいると思います。
ですが正規表現と促音・拗音への対応に分かりにくさを感じています。
特に拗音は濁音・半濁音と組み合わさることで複雑化しました。

ただ拗音の点字仕様については「きゃ」「きゅ」「きょ」が点字では「ゃき」「ゃく」「ゃこ」的な表現になることが実装するにあたって楽だったように思います。

ロジックを詳しく解説したブログ記事
=======================

ありません。

伊藤さんにメッセージ
=============

すみません。
「プロを目指す人のためのRuby入門」は持っていません。
